### PR TITLE
Fix Twitter's React Native dynamic stylesheet

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -310,16 +310,7 @@ function serializeNode(
         }
       }
       // dynamic stylesheet
-      if (
-        tagName === 'style' &&
-        (n as HTMLStyleElement).sheet &&
-        // TODO: Currently we only try to get dynamic stylesheet when it is an empty style element
-        !(
-          (n as HTMLElement).innerText ||
-          (n as HTMLElement).textContent ||
-          ''
-        ).trim().length
-      ) {
+      if (tagName === 'style' && (n as HTMLStyleElement).sheet) {
         const cssText = getCssRulesString(
           (n as HTMLStyleElement).sheet as CSSStyleSheet,
         );


### PR DESCRIPTION
# Summary
Twitter uses React Native which in turn dynamically changes the page stylesheet. If the recording starts before Twitter loads everything looks fine, but if the recording starts after it is complete loaded the content of `react-native-stylesheet` style element is not going to represent the final CSSOM as its `contentText` is not updated for dynamic CSSOM operations like [CSSStyleSheet.insertRule](fix-twitters-react-native-dynamic-stylesheet) and/or [CSSStyleSheet.deleteRule](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/deleteRule)